### PR TITLE
Align action buttons with repository title line

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -111,7 +111,7 @@ import '../styles/global.css';
 				const summaryHtml = renderMarkdown(repo.summary);
 
 				li.innerHTML = `
-					<div class="block p-4 cursor-pointer" data-url="${repo.url}">
+					<div class="block p-4">
 						<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="text-lg font-semibold text-blue-600 dark:text-blue-400 no-underline hover:underline">${repo.title}</a>
 						<div class="mt-1 text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none">${summaryHtml}</div>
 						<div class="mt-3 flex flex-wrap gap-2">
@@ -135,16 +135,6 @@ import '../styles/global.css';
 						</div>
 					</div>
 				`;
-
-				// Card click handler (excludes clicks on links inside summary)
-				const card = li.querySelector("[data-url]") as HTMLElement;
-				card.addEventListener("click", (e: MouseEvent) => {
-					const target = e.target as HTMLElement;
-					if (target.tagName === "A" || target.closest("a")) {
-						return;
-					}
-					window.open(repo.url, "_blank", "noopener,noreferrer");
-				});
 
 				return li;
 			}

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -112,12 +112,14 @@ import '../styles/global.css';
 
 				li.innerHTML = `
 					<div class="block p-4">
-						<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="text-lg font-semibold text-blue-600 dark:text-blue-400 no-underline hover:underline">${repo.title}</a>
-						<div class="mt-1 text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none">${summaryHtml}</div>
-						<div class="mt-3 flex flex-wrap gap-2">
-							<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300">GitHub</a>
-							${repo.deepWikiUrl ? `<a href="${repo.deepWikiUrl}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-emerald-500">DeepWiki</a>` : ''}
+						<div class="flex flex-wrap items-start justify-between gap-2">
+							<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="text-lg font-semibold text-blue-600 dark:text-blue-400 no-underline hover:underline">${repo.title}</a>
+							<div class="flex flex-wrap gap-2">
+								<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300">GitHub</a>
+								${repo.deepWikiUrl ? `<a href="${repo.deepWikiUrl}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-emerald-500">DeepWiki</a>` : ''}
+							</div>
 						</div>
+						<div class="mt-1 text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none">${summaryHtml}</div>
 						<div class="flex flex-wrap gap-4 mt-2 text-sm text-gray-500 dark:text-gray-400">
 							${languageHtml}
 							<span class="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- place repository title and action buttons (GitHub/DeepWiki) in a shared header row
- keep wrapping behavior for smaller screens via flex-wrap
- keep summary and metadata layout unchanged below the header

## Testing
- not run (local build tools are missing in this environment)