### PR TITLE
web: keep only DeepWiki link on repo title row

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -112,12 +112,14 @@ import '../styles/global.css';
 
 				li.innerHTML = `
 					<div class="block p-4">
-						<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="text-lg font-semibold text-blue-600 dark:text-blue-400 no-underline hover:underline">${repo.title}</a>
-						<div class="mt-1 text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none">${summaryHtml}</div>
-						<div class="mt-3 flex flex-wrap gap-2">
-							<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300">GitHub</a>
-							${repo.deepWikiUrl ? `<a href="${repo.deepWikiUrl}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-emerald-500">DeepWiki</a>` : ''}
+						<div class="flex flex-wrap items-start justify-between gap-2">
+							<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="text-lg font-semibold text-blue-600 dark:text-blue-400 no-underline hover:underline">${repo.title}</a>
+							<div class="flex flex-wrap gap-2">
+								<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300">GitHub</a>
+								${repo.deepWikiUrl ? `<a href="${repo.deepWikiUrl}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-emerald-500">DeepWiki</a>` : ''}
+							</div>
 						</div>
+						<div class="mt-1 text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none">${summaryHtml}</div>
 						<div class="flex flex-wrap gap-4 mt-2 text-sm text-gray-500 dark:text-gray-400">
 							${languageHtml}
 							<span class="flex items-center gap-1">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -114,11 +114,8 @@ import '../styles/global.css';
 					<div class="block p-4">
 						<div class="flex flex-wrap items-start justify-between gap-2">
 							<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="text-lg font-semibold text-blue-600 dark:text-blue-400 no-underline hover:underline">${repo.title}</a>
-							<div class="flex flex-wrap gap-2">
-								<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300">GitHub</a>
-								${repo.deepWikiUrl ? `<a href="${repo.deepWikiUrl}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-emerald-500">DeepWiki</a>` : ''}
-							</div>
-						</div>
+						${repo.deepWikiUrl ? `<a href="${repo.deepWikiUrl}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-emerald-500">DeepWiki</a>` : ''}
+					</div>
 						<div class="mt-1 text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none">${summaryHtml}</div>
 						<div class="flex flex-wrap gap-4 mt-2 text-sm text-gray-500 dark:text-gray-400">
 							${languageHtml}


### PR DESCRIPTION
## Summary
- Remove the GitHub action button from each repository card.
- Keep only the DeepWiki button and place it on the same top row as the repository title.
- Preserve the existing layout and metadata sections below the title row.