### PR TITLE
web: keep only DeepWiki link on repo title row

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -114,8 +114,8 @@ import '../styles/global.css';
 					<div class="block p-4">
 						<div class="flex flex-wrap items-start justify-between gap-2">
 							<a href="${repo.url}" target="_blank" rel="noopener noreferrer" class="text-lg font-semibold text-blue-600 dark:text-blue-400 no-underline hover:underline">${repo.title}</a>
-						${repo.deepWikiUrl ? `<a href="${repo.deepWikiUrl}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-emerald-500">DeepWiki</a>` : ''}
-					</div>
+							${repo.deepWikiUrl ? `<a href="${repo.deepWikiUrl}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-emerald-500">DeepWiki</a>` : ''}
+						</div>
 						<div class="mt-1 text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none">${summaryHtml}</div>
 						<div class="flex flex-wrap gap-4 mt-2 text-sm text-gray-500 dark:text-gray-400">
 							${languageHtml}


### PR DESCRIPTION
## Summary
- Show only the DeepWiki action for each repository card.
- Place the DeepWiki button on the same top row as the repository title.
- Remove duplicate action links below the summary area.