### PR TITLE
[codex] switch summaries to llama.cpp

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -6,7 +6,9 @@ on:
   workflow_dispatch:
 
 env:
-  OLLAMA_MODEL: gpt-oss:20b
+  LLAMA_CPP_REF: b8746
+  LLAMA_CPP_MODEL: gemma4:e4b
+  LLAMA_CPP_HF_MODEL: bartowski/google_gemma-4-E4B-it-GGUF:Q4_K_M
 
 jobs:
   generate:
@@ -23,31 +25,49 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # Ollamaのインストール
-      - name: Install Ollama
-        run: curl -fsSL https://ollama.com/install.sh | sh
-
-      # Ollamaモデルのキャッシュ
-      - name: Cache Ollama models
+      - name: Cache llama.cpp build
+        id: cache-llama-cpp
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ~/.ollama/models
-          key: ollama-${{ env.OLLAMA_MODEL }}
+          path: /tmp/llama.cpp/build
+          key: llama-cpp-${{ env.LLAMA_CPP_REF }}-${{ runner.os }}
 
-      # Ollamaサーバーを起動
-      - name: Start Ollama server
+      - name: Build llama.cpp
+        if: steps.cache-llama-cpp.outputs.cache-hit != 'true'
         run: |
-          ollama serve &
-          sleep 5
+          git clone --depth 1 --branch ${{ env.LLAMA_CPP_REF }} https://github.com/ggml-org/llama.cpp.git /tmp/llama.cpp
+          cmake -S /tmp/llama.cpp -B /tmp/llama.cpp/build -DLLAMA_BUILD_TESTS=OFF
+          cmake --build /tmp/llama.cpp/build --config Release --target llama-server -j "$(nproc)"
 
-      # モデルをpull
-      - name: Pull Ollama model
-        run: ollama pull ${{ env.OLLAMA_MODEL }}
+      - name: Cache Hugging Face models
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/huggingface
+          key: llama-model-gemma4-e4b-q4-k-m
+
+      - name: Start llama-server
+        run: |
+          /tmp/llama.cpp/build/bin/llama-server \
+            -hf "${{ env.LLAMA_CPP_HF_MODEL }}" \
+            --alias "${{ env.LLAMA_CPP_MODEL }}" \
+            --host 127.0.0.1 \
+            --port 8080 \
+            --ctx-size 12000 &
+
+          for i in $(seq 1 120); do
+            if curl -fsS http://127.0.0.1:8080/health; then
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "llama-server did not become healthy" >&2
+          exit 1
 
       - name: Run
         run: go run .
         env:
-          OLLAMA_MODEL: ${{ env.OLLAMA_MODEL }}
+          LLAMA_CPP_MODEL: ${{ env.LLAMA_CPP_MODEL }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_TOKEN }}
 
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -13,6 +13,7 @@ env:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       pages: write
@@ -52,7 +53,7 @@ jobs:
             --alias "${{ env.LLAMA_CPP_MODEL }}" \
             --host 127.0.0.1 \
             --port 8080 \
-            --ctx-size 12000 &
+            --ctx-size 4096 &
 
           for i in $(seq 1 120); do
             if curl -fsS http://127.0.0.1:8080/health; then

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,4 +12,3 @@ registries:
   ref: v4.497.0 # renovate: depName=aquaproj/aqua-registry
 packages:
 - name: suzuki-shunsuke/pinact@v3.9.0
-- name: ollama/ollama@v0.21.2

--- a/main.go
+++ b/main.go
@@ -109,11 +109,12 @@ type DiscordEmbedField struct {
 }
 
 const (
-	trendingAPIURL   = "https://raw.githubusercontent.com/isboyjc/github-trending-api/main/data/daily/all.json"
-	outputPath       = "./public/data.json"
-	feedPath         = "./public/feed.xml"
-	siteURL          = "https://github-trending-ja.yashikota.com"
-	defaultOllamaURL = "http://localhost:11434"
+	trendingAPIURL  = "https://raw.githubusercontent.com/isboyjc/github-trending-api/main/data/daily/all.json"
+	outputPath      = "./public/data.json"
+	feedPath        = "./public/feed.xml"
+	siteURL         = "https://github-trending-ja.yashikota.com"
+	defaultLlamaURL = "http://127.0.0.1:8080"
+	defaultModel    = "gemma4:e4b"
 )
 
 var httpClient = &http.Client{Timeout: 5 * time.Minute}
@@ -125,16 +126,18 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	// 1. Ollama設定取得
-	ollamaURL := os.Getenv("OLLAMA_HOST")
-	if ollamaURL == "" {
-		ollamaURL = defaultOllamaURL
+	// 1. llama.cpp設定取得
+	llamaURL := os.Getenv("LLAMA_CPP_BASE_URL")
+	if llamaURL == "" {
+		llamaURL = defaultLlamaURL
 	}
-	ollamaModel := os.Getenv("OLLAMA_MODEL")
-	if ollamaModel == "" {
-		return fmt.Errorf("OLLAMA_MODEL is not set")
+	llamaURL = strings.TrimRight(llamaURL, "/")
+
+	llamaModel := os.Getenv("LLAMA_CPP_MODEL")
+	if llamaModel == "" {
+		llamaModel = defaultModel
 	}
-	log.Printf("Using Ollama at %s with model %s", ollamaURL, ollamaModel)
+	log.Printf("Using llama.cpp at %s with model %s", llamaURL, llamaModel)
 
 	// Discord Webhook設定取得（オプショナル）
 	discordWebhookURL := os.Getenv("DISCORD_WEBHOOK_URL")
@@ -145,10 +148,10 @@ func run(ctx context.Context) error {
 	// 2. GitHubクライアント初期化
 	ghClient := github.NewClient(nil)
 
-	// 3. Ollamaクライアント初期化
-	ollamaClient := &OllamaClient{
-		BaseURL: ollamaURL,
-		Model:   ollamaModel,
+	// 3. llama.cppクライアント初期化
+	llamaClient := &LlamaCppClient{
+		BaseURL: llamaURL,
+		Model:   llamaModel,
 		HTTP:    &http.Client{Timeout: 30 * time.Minute},
 	}
 
@@ -181,7 +184,7 @@ func run(ctx context.Context) error {
 		}
 
 		// 要約生成
-		summary, err := ollamaClient.Summarize(ctx, readme)
+		summary, err := llamaClient.Summarize(ctx, readme)
 		if err != nil {
 			log.Printf("WARN: failed to summarize: %v", err)
 			summary = "要約失敗"
@@ -264,27 +267,35 @@ func fetchReadme(ctx context.Context, client *github.Client, owner, name string)
 	return content, nil
 }
 
-// OllamaClient はOllama APIクライアント
-type OllamaClient struct {
+// LlamaCppClient はllama.cppのOpenAI互換APIクライアント
+type LlamaCppClient struct {
 	BaseURL string
 	Model   string
 	HTTP    *http.Client
 }
 
-// OllamaRequest はOllama APIへのリクエスト
-type OllamaRequest struct {
-	Model  string `json:"model"`
-	Prompt string `json:"prompt"`
-	Stream bool   `json:"stream"`
+type ChatCompletionRequest struct {
+	Model              string         `json:"model"`
+	Messages           []ChatMessage  `json:"messages"`
+	Stream             bool           `json:"stream"`
+	MaxTokens          int            `json:"max_tokens"`
+	Temperature        float64        `json:"temperature"`
+	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
 }
 
-// OllamaResponse はOllama APIからのレスポンス
-type OllamaResponse struct {
-	Response string `json:"response"`
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatCompletionResponse struct {
+	Choices []struct {
+		Message ChatMessage `json:"message"`
+	} `json:"choices"`
 }
 
 // Summarize はREADMEを日本語で要約する
-func (c *OllamaClient) Summarize(ctx context.Context, readme string) (string, error) {
+func (c *LlamaCppClient) Summarize(ctx context.Context, readme string) (string, error) {
 	// READMEが空の場合
 	if readme == "" {
 		return "説明なし", nil
@@ -296,15 +307,24 @@ func (c *OllamaClient) Summarize(ctx context.Context, readme string) (string, er
 		readme = readme[:maxReadmeLen]
 	}
 
-	prompt := fmt.Sprintf(
-		"以下のREADMEの内容を日本語で短く要約せよ。100文字以内で\n\n%s",
-		readme,
-	)
-
-	reqBody := OllamaRequest{
-		Model:  c.Model,
-		Prompt: prompt,
-		Stream: false,
+	reqBody := ChatCompletionRequest{
+		Model: c.Model,
+		Messages: []ChatMessage{
+			{
+				Role:    "system",
+				Content: "あなたはGitHubリポジトリのREADMEを日本語で短く要約するアシスタントです。出力は100文字以内の日本語要約のみとし、前置きや箇条書きは不要です。",
+			},
+			{
+				Role:    "user",
+				Content: fmt.Sprintf("以下のREADMEの内容を日本語で短く要約せよ。\n\n%s", readme),
+			},
+		},
+		Stream:      false,
+		MaxTokens:   160,
+		Temperature: 0.2,
+		ChatTemplateKwargs: map[string]any{
+			"enable_thinking": false,
+		},
 	}
 
 	jsonData, err := json.Marshal(reqBody)
@@ -312,7 +332,7 @@ func (c *OllamaClient) Summarize(ctx context.Context, readme string) (string, er
 		return "", fmt.Errorf("marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/generate", bytes.NewReader(jsonData))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(jsonData))
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
 	}
@@ -328,16 +348,16 @@ func (c *OllamaClient) Summarize(ctx context.Context, readme string) (string, er
 		return "", fmt.Errorf("unexpected status: %d", resp.StatusCode)
 	}
 
-	var ollamaResp OllamaResponse
-	if err := json.NewDecoder(resp.Body).Decode(&ollamaResp); err != nil {
+	var chatResp ChatCompletionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&chatResp); err != nil {
 		return "", fmt.Errorf("decode response: %w", err)
 	}
 
-	if ollamaResp.Response == "" {
+	if len(chatResp.Choices) == 0 || chatResp.Choices[0].Message.Content == "" {
 		return "要約失敗", nil
 	}
 
-	return strings.TrimSpace(ollamaResp.Response), nil
+	return strings.TrimSpace(chatResp.Choices[0].Message.Content), nil
 }
 
 func writeJSON(path string, data any) error {

--- a/main.go
+++ b/main.go
@@ -301,8 +301,8 @@ func (c *LlamaCppClient) Summarize(ctx context.Context, readme string) (string, 
 		return "説明なし", nil
 	}
 
-	// READMEが長すぎる場合は切り詰め（トークン節約）
-	const maxReadmeLen = 10000
+	// READMEが長すぎる場合は切り詰め（CPU推論の時間を抑える）
+	const maxReadmeLen = 2000
 	if len(readme) > maxReadmeLen {
 		readme = readme[:maxReadmeLen]
 	}
@@ -320,7 +320,7 @@ func (c *LlamaCppClient) Summarize(ctx context.Context, readme string) (string, 
 			},
 		},
 		Stream:      false,
-		MaxTokens:   160,
+		MaxTokens:   80,
 		Temperature: 0.2,
 		ChatTemplateKwargs: map[string]any{
 			"enable_thinking": false,


### PR DESCRIPTION
## Summary
- replace the Ollama generate call with llama.cpp OpenAI-compatible chat completions
- default local inference to `LLAMA_CPP_BASE_URL=http://127.0.0.1:8080` and `LLAMA_CPP_MODEL=gemma4:e4b`
- update the scheduled workflow to build/run `llama-server` with Gemma 4 E4B GGUF and cache the build/model

## Validation
- `go test ./...`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/run.yaml"); YAML.load_file("aqua.yaml")'`\n- `git diff --check`