### PR TITLE
switch to prebuilt llama.cpp binary and Bonsai 8B model

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -6,9 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  LLAMA_CPP_REF: b8746
-  LLAMA_CPP_MODEL: gemma4:e4b
-  LLAMA_CPP_HF_MODEL: bartowski/google_gemma-4-E4B-it-GGUF:Q4_K_M
+  LLAMA_CPP_VERSION: b8967
+  LLAMA_CPP_HF_MODEL: prism-ml/Bonsai-8B-gguf:Q1_0
 
 jobs:
   generate:
@@ -26,31 +25,27 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Cache llama.cpp build
-        id: cache-llama-cpp
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/llama.cpp/build
-          key: llama-cpp-${{ env.LLAMA_CPP_REF }}-${{ runner.os }}
-
-      - name: Build llama.cpp
-        if: steps.cache-llama-cpp.outputs.cache-hit != 'true'
+      - name: Download llama.cpp
         run: |
-          git clone --depth 1 --branch ${{ env.LLAMA_CPP_REF }} https://github.com/ggml-org/llama.cpp.git /tmp/llama.cpp
-          cmake -S /tmp/llama.cpp -B /tmp/llama.cpp/build -DLLAMA_BUILD_TESTS=OFF
-          cmake --build /tmp/llama.cpp/build --config Release --target llama-server -j "$(nproc)"
+          gh release download "${{ env.LLAMA_CPP_VERSION }}" \
+            --repo ggml-org/llama.cpp \
+            --pattern 'llama-*-bin-ubuntu-x64.tar.gz' \
+            --dir /tmp
+          mkdir -p /tmp/llama.cpp
+          tar -xvf /tmp/llama-*-bin-ubuntu-x64.tar.gz -C /tmp/llama.cpp --strip-components=1
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Cache Hugging Face models
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/huggingface
-          key: llama-model-gemma4-e4b-q4-k-m
+          key: hf-${{ env.LLAMA_CPP_HF_MODEL }}
 
       - name: Start llama-server
         run: |
-          /tmp/llama.cpp/build/bin/llama-server \
+          /tmp/llama.cpp/llama-server \
             -hf "${{ env.LLAMA_CPP_HF_MODEL }}" \
-            --alias "${{ env.LLAMA_CPP_MODEL }}" \
             --host 127.0.0.1 \
             --port 8080 \
             --ctx-size 4096 &
@@ -68,7 +63,6 @@ jobs:
       - name: Run
         run: go run .
         env:
-          LLAMA_CPP_MODEL: ${{ env.LLAMA_CPP_MODEL }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_TOKEN }}
 
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ const (
 	feedPath        = "./public/feed.xml"
 	siteURL         = "https://github-trending-ja.yashikota.com"
 	defaultLlamaURL = "http://127.0.0.1:8080"
-	defaultModel    = "gemma4:e4b"
 )
 
 var httpClient = &http.Client{Timeout: 5 * time.Minute}
@@ -132,12 +131,7 @@ func run(ctx context.Context) error {
 		llamaURL = defaultLlamaURL
 	}
 	llamaURL = strings.TrimRight(llamaURL, "/")
-
-	llamaModel := os.Getenv("LLAMA_CPP_MODEL")
-	if llamaModel == "" {
-		llamaModel = defaultModel
-	}
-	log.Printf("Using llama.cpp at %s with model %s", llamaURL, llamaModel)
+	log.Printf("Using llama.cpp at %s", llamaURL)
 
 	// Discord Webhook設定取得（オプショナル）
 	discordWebhookURL := os.Getenv("DISCORD_WEBHOOK_URL")
@@ -151,7 +145,6 @@ func run(ctx context.Context) error {
 	// 3. llama.cppクライアント初期化
 	llamaClient := &LlamaCppClient{
 		BaseURL: llamaURL,
-		Model:   llamaModel,
 		HTTP:    &http.Client{Timeout: 30 * time.Minute},
 	}
 
@@ -270,17 +263,14 @@ func fetchReadme(ctx context.Context, client *github.Client, owner, name string)
 // LlamaCppClient はllama.cppのOpenAI互換APIクライアント
 type LlamaCppClient struct {
 	BaseURL string
-	Model   string
 	HTTP    *http.Client
 }
 
 type ChatCompletionRequest struct {
-	Model              string         `json:"model"`
-	Messages           []ChatMessage  `json:"messages"`
-	Stream             bool           `json:"stream"`
-	MaxTokens          int            `json:"max_tokens"`
-	Temperature        float64        `json:"temperature"`
-	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
+	Messages    []ChatMessage `json:"messages"`
+	Stream      bool          `json:"stream"`
+	MaxTokens   int           `json:"max_tokens"`
+	Temperature float64       `json:"temperature"`
 }
 
 type ChatMessage struct {
@@ -308,7 +298,6 @@ func (c *LlamaCppClient) Summarize(ctx context.Context, readme string) (string, 
 	}
 
 	reqBody := ChatCompletionRequest{
-		Model: c.Model,
 		Messages: []ChatMessage{
 			{
 				Role:    "system",
@@ -322,9 +311,6 @@ func (c *LlamaCppClient) Summarize(ctx context.Context, readme string) (string, 
 		Stream:      false,
 		MaxTokens:   80,
 		Temperature: 0.2,
-		ChatTemplateKwargs: map[string]any{
-			"enable_thinking": false,
-		},
 	}
 
 	jsonData, err := json.Marshal(reqBody)


### PR DESCRIPTION
## Summary
- llama.cpp をソースビルドからプレビルドバイナリのダウンロードに変更（ビルド時間削減）
- モデルを Gemma 4 E4B (Q4_K_M) から Bonsai 8B (Q1_0) に変更（1bit量子化、省メモリ）
- Go コードからモデル名関連のフィールド・設定を全て削除

## Test plan
- [ ] `workflow_dispatch` で手動実行して動作確認